### PR TITLE
Revamp home dashboard hero and risk analytics

### DIFF
--- a/.github/ISSUE_TEMPLATE/activate-dashboard-filters.md
+++ b/.github/ISSUE_TEMPLATE/activate-dashboard-filters.md
@@ -1,0 +1,24 @@
+---
+name: Activate dashboard filters
+about: Track the work to make homepage analytics respond to portfolio filters.
+title: "Activate Dashboard Filters"
+labels: enhancement, frontend
+---
+
+## Summary
+
+See `docs/issues/activate-dashboard-filters.md` for the detailed problem statement, impact, execution plan, and acceptance criteria.
+
+## Action Items
+
+- [ ] Implement shared filter state (`usePortfolioFilters` hook or provider) and derive filtered customer data.
+- [ ] Update dashboard analytics (`CreditDistributionChart`, `RiskHeatmap`, `TopClientsSpotlight`, `TopExposuresTable`) to consume the filtered data.
+- [ ] Align hero metrics and KPIs with filtered values or document any global-only exceptions.
+- [ ] Add empty-state messaging when filters/search yield no customers.
+- [ ] Complete manual QA notes and add follow-up tasks as needed.
+
+## Validation
+
+- [ ] All filters and search box update analytics instantly.
+- [ ] Accessibility checks pass (keyboard navigation, screen reader output).
+- [ ] No regression to default metrics when filters reset to "all".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `src/pages` hosts route-level React screens; `src/components` houses reusable UI built with shadcn and Tailwind; `src/services` centralizes data providers while `src/lib` collects utility helpers.
+- Global providers and routing live in `src/App.tsx`, with `src/main.tsx` wiring the React root. Styling globals sit in `src/index.css` and `src/App.css`.
+- Static assets belong in `public/`. Built artifacts land in `dist/`. Sample datasets reside in `data/`, and `scripts/seedClientDatabase.ts` keeps the demo SQLite output deterministic.
+
+## Build, Test & Development Commands
+- `npm run dev` starts Vite with hot module reload at `http://localhost:5173`.
+- `npm run build` produces an optimized bundle inside `dist/`; pair with `npm run preview` to verify the production build locally.
+- `npm run lint` executes ESLint across the workspace; resolve all warnings before you push.
+- `npm run seed:clients` writes `data/client_data.db` so you can inspect consistent credit-risk fixtures.
+
+## Coding Style & Naming Conventions
+- Stick to TypeScript, ES module imports, and 2-space indentation. Enable strict types when adding tsconfig settings.
+- Name React components, hooks, and services with PascalCase files (`RiskHeatmap.tsx`, `usePortfolioFilters.ts`); utilities and constants may use camelCase (`formatCurrency.ts`).
+- Favor Tailwind utility classes for layout; keep shared variants in component files and extend tokens through `tailwind.config.ts` when needed.
+
+## Testing Guidelines
+- Automated tests are not yet configured; add Vitest + React Testing Library coverage alongside new features (`src/components/__tests__/RiskHeatmap.test.tsx`).
+- Target ≥80% coverage on new modules, focusing on data transforms and interactive flows. Document manual QA steps in the PR when tests are unavailable.
+- Seed fresh data via `npm run seed:clients` before validating analytics or navigation scenarios.
+
+## Commit & Pull Request Guidelines
+- Write imperative, present-tense commit titles (`Revamp dashboard hero`, `chore(deps): update eslint`). Include a concise scope in parentheses only when it adds clarity.
+- PRs should summarize the change, list validation commands, link issues or specs, and attach screenshots or clips for UI updates.
+- Confirm `npm run lint` and `npm run build` succeed locally before requesting review. Call out follow-up tasks or known gaps explicitly to keep the dashboard stable.

--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -1,0 +1,19 @@
+# Future Improvement Plan
+
+The initiatives below are ordered by impact on dashboard reliability, accessibility, and team velocity. Each item includes a short rationale along with complexity and expected productivity gain estimates to guide planning.
+
+| Rank | Initiative | Rationale | Complexity | Productivity Gain |
+| --- | --- | --- | --- | --- |
+| 1 | Stabilize sidebar-responsive layout | Reinstate a consistent content offset for sub-`lg` viewports so analytics remain visible when the sidebar toggles widths. Prevents current overlap that blocks mobile workflows. | Medium | High |
+| 2 | Wire accessible interactions for `RiskHeatmap` cells | Replace inert buttons with actionable handlers (e.g., drill-down modal) and ARIA labels to support keyboard and screen-reader users, aligning with accessibility goals. Layer in hover/click tooltips that expose portfolio summaries so analysts can inspect concentration risk without leaving the main dashboard. | Medium | Medium |
+| 3 | Stand up Vitest + React Testing Library suite | Introduce component and hook tests for risk analytics and navigation flows, unlocking CI confidence and coverage for future refactors called out in `IMPROVEMENT_CHECKLIST.md`. | Medium-High | High |
+| 4 | Modularize data services and state management | Split fetching, transformation, and caching into dedicated modules and consider a lightweight store (Zustand) to reduce prop drilling and duplicate queries. | High | Medium-High |
+| 5 | Automate data quality monitoring pipeline | Expand the deterministic seeding script into scheduled validation checks (missing values, outliers) with alerts, ensuring dashboards stay trustworthy as data sources scale. | High | High |
+
+Focus on ranks 1–2 during the next sprint to resolve blocking usability issues called out in reviews. Ranks 3–5 can be sequenced into subsequent iterations, with test infrastructure laying the groundwork for safer service refactors and data governance upgrades.
+
+## RiskHeatmap Interaction Workstream
+- **Interaction model**: Convert each cell into a focusable button that toggles the risk-segment detail drawer and dispatches filters to downstream charts.
+- **Accessibility polish**: Annotate the grid with ARIA roles, stateful labels (e.g., `aria-pressed`), and keyboard shortcuts that mirror the pointer experience.
+- **Contextual insights**: Introduce tooltip metadata (top counterparties, exposure deltas) that load from the existing portfolio service to keep interactions performant.
+- **QA plan**: Pair manual screen reader sweeps with new Vitest integration tests to validate keyboard navigation, filter dispatching, and tooltip visibility.

--- a/FUTURE_IMPROVEMENTS.md
+++ b/FUTURE_IMPROVEMENTS.md
@@ -1,19 +1,19 @@
 # Future Improvement Plan
 
-The initiatives below are ordered by impact on dashboard reliability, accessibility, and team velocity. Each item includes a short rationale along with complexity and expected productivity gain estimates to guide planning.
+The initiatives below are ordered by impact on dashboard reliability, accessibility, and team velocity. Each item now carries a status update so we can track momentum.
 
-| Rank | Initiative | Rationale | Complexity | Productivity Gain |
-| --- | --- | --- | --- | --- |
-| 1 | Stabilize sidebar-responsive layout | Reinstate a consistent content offset for sub-`lg` viewports so analytics remain visible when the sidebar toggles widths. Prevents current overlap that blocks mobile workflows. | Medium | High |
-| 2 | Wire accessible interactions for `RiskHeatmap` cells | Replace inert buttons with actionable handlers (e.g., drill-down modal) and ARIA labels to support keyboard and screen-reader users, aligning with accessibility goals. Layer in hover/click tooltips that expose portfolio summaries so analysts can inspect concentration risk without leaving the main dashboard. | Medium | Medium |
-| 3 | Stand up Vitest + React Testing Library suite | Introduce component and hook tests for risk analytics and navigation flows, unlocking CI confidence and coverage for future refactors called out in `IMPROVEMENT_CHECKLIST.md`. | Medium-High | High |
-| 4 | Modularize data services and state management | Split fetching, transformation, and caching into dedicated modules and consider a lightweight store (Zustand) to reduce prop drilling and duplicate queries. | High | Medium-High |
-| 5 | Automate data quality monitoring pipeline | Expand the deterministic seeding script into scheduled validation checks (missing values, outliers) with alerts, ensuring dashboards stay trustworthy as data sources scale. | High | High |
+| Rank | Initiative | Status | Rationale | Complexity | Productivity Gain |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Stabilize sidebar-responsive layout | ✅ Completed — content now respects sidebar width at all breakpoints. | Reinstate a consistent content offset for sub-`lg` viewports so analytics remain visible when the sidebar toggles widths. Prevents previous overlap that blocked mobile workflows. | Medium | High |
+| 2 | Wire accessible interactions for `RiskHeatmap` cells | ✅ Completed — heatmap cells announce context, support keyboard focus, and surface live status feedback. | Replace inert buttons with actionable handlers (e.g., drill-down modal) and ARIA labels to support keyboard and screen-reader users, aligning with accessibility goals. | Medium | Medium |
+| 3 | Stand up Vitest + React Testing Library suite | ⏳ Planned | Introduce component and hook tests for risk analytics and navigation flows, unlocking CI confidence and coverage for future refactors called out in `IMPROVEMENT_CHECKLIST.md`. | Medium-High | High |
+| 4 | Modularize data services and state management | ⏳ Planned | Split fetching, transformation, and caching into dedicated modules and consider a lightweight store (Zustand) to reduce prop drilling and duplicate queries. | High | Medium-High |
+| 5 | Automate data quality monitoring pipeline | ⏳ Planned | Expand the deterministic seeding script into scheduled validation checks (missing values, outliers) with alerts, ensuring dashboards stay trustworthy as data sources scale. | High | High |
 
-Focus on ranks 1–2 during the next sprint to resolve blocking usability issues called out in reviews. Ranks 3–5 can be sequenced into subsequent iterations, with test infrastructure laying the groundwork for safer service refactors and data governance upgrades.
+Next priority: invest in rank 3 to lay testing groundwork before tackling broader architectural and data-governance upgrades (ranks 4–5).
 
 ## RiskHeatmap Interaction Workstream
-- **Interaction model**: Convert each cell into a focusable button that toggles the risk-segment detail drawer and dispatches filters to downstream charts.
-- **Accessibility polish**: Annotate the grid with ARIA roles, stateful labels (e.g., `aria-pressed`), and keyboard shortcuts that mirror the pointer experience.
-- **Contextual insights**: Introduce tooltip metadata (top counterparties, exposure deltas) that load from the existing portfolio service to keep interactions performant.
-- **QA plan**: Pair manual screen reader sweeps with new Vitest integration tests to validate keyboard navigation, filter dispatching, and tooltip visibility.
+- **Complete**: Cells are now focusable buttons with ARIA semantics, selection rings, and a live status region that narrates the active segment.
+- **Next**: Decide whether to trigger a modal or dispatch filters to downstream charts when a cell is activated; capture the chosen behavior in analytics.
+- **Enhance**: Layer tooltip metadata (top counterparties, exposure deltas) sourced from the portfolio service to enrich the at-a-glance experience without extra navigation.
+- **QA plan**: Pair manual screen-reader sweeps with the upcoming Vitest suite to cover keyboard traversal, announced summaries, and any new drill-down behaviors.

--- a/docs/issues/activate-dashboard-filters.md
+++ b/docs/issues/activate-dashboard-filters.md
@@ -1,0 +1,24 @@
+# Issue: Activate Dashboard Filters
+
+## Summary
+- Portfolio filter controls on `src/pages/Index.tsx` capture state but downstream cards, charts, and tables continue to query the full dataset.
+- Users click the filters expecting the rest of the dashboard to respond; the unresponsive experience erodes trust in the analytics.
+- We need a shared data pipeline so every analytic respects the selected rating, sector, region, and search term.
+
+## Impact
+- Restores credibility by making the interface react instantly to user intent.
+- Reduces context switching—analysts can zero in on risky segments without exporting data.
+- Lays the groundwork for future drill-down workflows and coordinated filtering across routes.
+
+## Execution Plan
+1. Extract a `usePortfolioFilters` hook (or context provider) that exposes filter state, setters, and a derived `filteredCustomers` collection.
+2. Refactor `CustomerDataService` access so components consume the filtered data instead of the raw `getAllCustomers()` collection.
+3. Update `CreditDistributionChart`, `RiskHeatmap`, `TopClientsSpotlight`, and `TopExposuresTable` to accept data props or hook into the shared context; mirror empty-state messaging when filters return no rows.
+4. Extend hero highlights and KPI cards to derive metrics from the filtered slice where appropriate, noting any values that must remain global.
+5. QA: manual sanity checks (rating/sector/region combinations, search term) plus smoke tests for navigation; record follow-up tasks for perf tuning or caching once behavior is live.
+
+## Acceptance Criteria
+- Filters and search update all dashboard analytics within a frame, without page reloads.
+- Empty/edge states render helpful guidance (e.g., “No customers match the current filters”).
+- No regressions to initial load: default view mirrors today’s totals when filters are set to “all” and search is blank.
+- Accessibility remains intact (keyboard tab order, focus management, ARIA labels) after wiring the filter interactions.

--- a/src/components/CreditDistributionChart.tsx
+++ b/src/components/CreditDistributionChart.tsx
@@ -1,75 +1,122 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Line, ComposedChart } from 'recharts';
+import {
+  ComposedChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Line,
+  Area,
+  Legend,
+  LabelList,
+  ReferenceLine,
+} from "recharts";
 
 const CreditDistributionChart = () => {
   const data = [
-    { rating: 'AAA', count: 145, percentage: 12.1, cumulative: 12.1 },
-    { rating: 'AA', count: 98, percentage: 8.2, cumulative: 20.3 },
-    { rating: 'A', count: 187, percentage: 15.6, cumulative: 35.9 },
-    { rating: 'BBB', count: 234, percentage: 19.5, cumulative: 55.4 },
-    { rating: 'BB', count: 189, percentage: 15.8, cumulative: 71.2 },
-    { rating: 'B', count: 156, percentage: 13.0, cumulative: 84.2 },
-    { rating: 'CCC', count: 98, percentage: 8.2, cumulative: 92.4 },
-    { rating: 'Below CCC', count: 91, percentage: 7.6, cumulative: 100.0 }
+    { rating: "AAA", count: 145, percentage: 12.1, cumulative: 12.1 },
+    { rating: "AA", count: 98, percentage: 8.2, cumulative: 20.3 },
+    { rating: "A", count: 187, percentage: 15.6, cumulative: 35.9 },
+    { rating: "BBB", count: 234, percentage: 19.5, cumulative: 55.4 },
+    { rating: "BB", count: 189, percentage: 15.8, cumulative: 71.2 },
+    { rating: "B", count: 156, percentage: 13.0, cumulative: 84.2 },
+    { rating: "CCC", count: 98, percentage: 8.2, cumulative: 92.4 },
+    { rating: "Below CCC", count: 91, percentage: 7.6, cumulative: 100.0 },
   ];
 
+  const avgCount = Math.round(
+    data.reduce((total, current) => total + current.count, 0) / data.length
+  );
+
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader>
         <CardTitle className="text-lg">Credit Rating Distribution</CardTitle>
-        <p className="text-sm text-gray-600">Portfolio breakdown by credit rating</p>
+        <p className="text-sm text-gray-600">Visualise concentration by rating and cumulative share</p>
       </CardHeader>
       <CardContent>
         <div className="h-80">
           <ResponsiveContainer width="100%" height="100%">
-            <ComposedChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
-              <XAxis 
-                dataKey="rating" 
-                tick={{ fontSize: 12 }}
-                axisLine={{ stroke: '#e0e0e0' }}
+            <ComposedChart data={data} margin={{ top: 24, right: 24, left: 16, bottom: 8 }}>
+              <defs>
+                <linearGradient id="ratingDistribution" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor="#2563eb" stopOpacity={0.9} />
+                  <stop offset="95%" stopColor="#60a5fa" stopOpacity={0.4} />
+                </linearGradient>
+                <linearGradient id="ratingArea" x1="0" y1="0" x2="1" y2="0">
+                  <stop offset="0%" stopColor="#34d399" stopOpacity={0.35} />
+                  <stop offset="100%" stopColor="#22d3ee" stopOpacity={0.2} />
+                </linearGradient>
+              </defs>
+              <CartesianGrid strokeDasharray="4 4" stroke="#e5e7eb" />
+              <XAxis
+                dataKey="rating"
+                tick={{ fontSize: 12, fill: "#4b5563" }}
+                axisLine={{ stroke: "#d1d5db" }}
+                tickLine={false}
               />
-              <YAxis 
+              <YAxis
                 yAxisId="left"
-                tick={{ fontSize: 12 }}
-                axisLine={{ stroke: '#e0e0e0' }}
-                label={{ value: 'Count', angle: -90, position: 'insideLeft' }}
+                tick={{ fontSize: 12, fill: "#4b5563" }}
+                axisLine={{ stroke: "#d1d5db" }}
+                tickLine={false}
+                label={{ value: "Count", angle: -90, position: "insideLeft", fill: "#6b7280" }}
               />
-              <YAxis 
-                yAxisId="right" 
+              <YAxis
+                yAxisId="right"
                 orientation="right"
-                tick={{ fontSize: 12 }}
-                axisLine={{ stroke: '#e0e0e0' }}
-                label={{ value: 'Cumulative %', angle: 90, position: 'insideRight' }}
+                tick={{ fontSize: 12, fill: "#4b5563" }}
+                axisLine={{ stroke: "#d1d5db" }}
+                tickLine={false}
+                label={{ value: "Cumulative %", angle: 90, position: "insideRight", fill: "#6b7280" }}
               />
-              <Tooltip 
+              <Tooltip
                 formatter={(value, name) => {
-                  if (name === 'count') return [value, 'Count'];
-                  if (name === 'cumulative') return [`${value}%`, 'Cumulative %'];
+                  if (name === "count") return [value, "Customers"];
+                  if (name === "percentage") return [`${value}%`, "Portfolio Share"];
+                  if (name === "cumulative") return [`${value}%`, "Cumulative"];
                   return [value, name];
                 }}
                 labelFormatter={(label) => `Rating: ${label}`}
                 contentStyle={{
-                  backgroundColor: 'white',
-                  border: '1px solid #e0e0e0',
-                  borderRadius: '8px',
-                  boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+                  backgroundColor: "white",
+                  border: "1px solid #e5e7eb",
+                  borderRadius: "0.75rem",
+                  boxShadow: "0 10px 40px -24px rgba(15, 23, 42, 0.45)",
                 }}
               />
-              <Bar 
-                yAxisId="left"
-                dataKey="count" 
-                fill="#3b82f6" 
-                radius={[2, 2, 0, 0]}
-              />
-              <Line 
+              <Legend verticalAlign="top" height={36} iconType="circle" />
+              <ReferenceLine yAxisId="left" y={avgCount} stroke="#94a3b8" strokeDasharray="6 6" label={{ value: `Avg ${avgCount}`, position: "insideTopRight", fill: "#64748b" }} />
+              <Area
                 yAxisId="right"
-                type="monotone" 
-                dataKey="cumulative" 
-                stroke="#ef4444" 
+                type="monotone"
+                dataKey="percentage"
+                fill="url(#ratingArea)"
+                stroke="#10b981"
                 strokeWidth={2}
-                dot={{ fill: '#ef4444', strokeWidth: 2, r: 4 }}
+                name="Portfolio share"
+                dot={{ r: 3, fill: "#10b981" }}
+              />
+              <Bar
+                yAxisId="left"
+                dataKey="count"
+                fill="url(#ratingDistribution)"
+                radius={[8, 8, 0, 0]}
+                name="Customers"
+              >
+                <LabelList dataKey="count" position="top" fill="#1f2937" formatter={(value: number) => value.toLocaleString()} />
+              </Bar>
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="cumulative"
+                stroke="#f97316"
+                strokeWidth={2}
+                dot={{ fill: "#f97316", strokeWidth: 2, r: 4 }}
+                name="Cumulative"
               />
             </ComposedChart>
           </ResponsiveContainer>

--- a/src/components/RiskHeatmap.tsx
+++ b/src/components/RiskHeatmap.tsx
@@ -2,85 +2,106 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const RiskHeatmap = () => {
-  const ratings = ['AAA', 'AA', 'A', 'BBB', 'BB'];
-  const exposureBands = ['> $5M', '$2-5M', '$1-2M', '$500K-1M', '< $500K'];
-  
+  const ratings = ["AAA", "AA", "A", "BBB", "BB"];
+  const exposureBands = ["> $5M", "$2-5M", "$1-2M", "$500K-1M", "< $500K"];
+
   // Mock data for heatmap - each cell represents count of customers
   const heatmapData = [
     [5, 12, 23, 45, 78],
     [8, 18, 34, 67, 89],
     [12, 25, 48, 89, 134],
     [18, 34, 67, 123, 189],
-    [25, 45, 78, 156, 234]
+    [25, 45, 78, 156, 234],
   ];
 
-  const getIntensity = (value: number) => {
-    const max = Math.max(...heatmapData.flat());
-    const intensity = value / max;
-    
-    if (intensity > 0.8) return 'bg-red-500';
-    if (intensity > 0.6) return 'bg-red-400';
-    if (intensity > 0.4) return 'bg-orange-400';
-    if (intensity > 0.2) return 'bg-yellow-400';
-    if (intensity > 0.1) return 'bg-green-400';
-    return 'bg-green-200';
+  const maxValue = Math.max(...heatmapData.flat());
+
+  const getCellStyle = (value: number) => {
+    const intensity = value / maxValue;
+    const hue = 155 - intensity * 120;
+    const saturation = 75 + intensity * 10;
+    const lightness = 55 - intensity * 20;
+
+    return {
+      background: `linear-gradient(135deg, hsla(${hue}, ${saturation}%, ${lightness}%, 0.95), hsla(${hue - 10}, ${saturation}%, ${lightness - 8}%, 0.95))`,
+      color: intensity > 0.45 ? "#f8fafc" : "#0f172a",
+      boxShadow: intensity > 0.35 ? "inset 0 0 0 1px rgba(15, 23, 42, 0.1)" : "inset 0 0 0 1px rgba(15, 23, 42, 0.04)",
+    };
   };
 
-  const getTextColor = (value: number) => {
-    const max = Math.max(...heatmapData.flat());
-    const intensity = value / max;
-    return intensity > 0.4 ? 'text-white' : 'text-gray-800';
+  const getSummary = () => {
+    const highestRowIndex = heatmapData.reduce((highestIndex, row, index, arr) => {
+      const rowTotal = row.reduce((sum, value) => sum + value, 0);
+      const highestTotal = arr[highestIndex].reduce((sum, value) => sum + value, 0);
+      return rowTotal > highestTotal ? index : highestIndex;
+    }, 0);
+
+    const highestSegment = heatmapData.reduce(
+      (best, row, ratingIndex) => {
+        let currentBest = best;
+        row.forEach((value, bandIndex) => {
+          if (value > currentBest.value) {
+            currentBest = { value, ratingIndex, bandIndex };
+          }
+        });
+        return currentBest;
+      },
+      { value: Number.NEGATIVE_INFINITY, ratingIndex: 0, bandIndex: 0 }
+    );
+
+    return `Largest customer volume is concentrated in ${ratings[highestRowIndex]} with the ${exposureBands[highestSegment.bandIndex]} band peaking at ${highestSegment.value} customers.`;
   };
 
   return (
-    <Card>
+    <Card className="h-full">
       <CardHeader>
         <CardTitle className="text-lg">Risk Heatmap</CardTitle>
-        <p className="text-sm text-gray-600">Exposure vs Credit Rating matrix</p>
+        <p className="text-sm text-gray-600">Exposure vs credit rating matrix with intensity-driven insights</p>
       </CardHeader>
-      <CardContent>
-        <div className="space-y-2">
-          {/* Header row */}
-          <div className="grid grid-cols-6 gap-1">
-            <div className="p-2 text-xs font-medium text-gray-600">Rating / Exposure</div>
-            {exposureBands.map((band, index) => (
-              <div key={index} className="p-2 text-xs font-medium text-gray-600 text-center">
+      <CardContent className="space-y-4">
+        <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-slate-50/60 shadow-inner">
+          <div className="grid grid-cols-[120px_repeat(5,_minmax(0,_1fr))] divide-x divide-slate-200/70 text-xs font-medium uppercase tracking-wide text-slate-500">
+            <div className="bg-white/80 px-3 py-3 text-left">Rating / Exposure</div>
+            {exposureBands.map((band) => (
+              <div key={band} className="bg-white/60 px-3 py-3 text-center">
                 {band}
               </div>
             ))}
           </div>
-          
-          {/* Data rows */}
-          {ratings.map((rating, ratingIndex) => (
-            <div key={rating} className="grid grid-cols-6 gap-1">
-              <div className="p-2 text-xs font-medium text-gray-600 flex items-center">
-                {rating}
-              </div>
-              {heatmapData[ratingIndex].map((value, exposureIndex) => (
-                <div
-                  key={exposureIndex}
-                  className={`p-2 text-xs font-medium text-center rounded transition-colors hover:opacity-80 cursor-pointer ${getIntensity(value)} ${getTextColor(value)}`}
-                  title={`${rating} rating, ${exposureBands[exposureIndex]}: ${value} customers`}
-                >
-                  {value}
+          <div className="divide-y divide-slate-200/70 text-sm">
+            {ratings.map((rating, ratingIndex) => (
+              <div key={rating} className="grid grid-cols-[120px_repeat(5,_minmax(0,_1fr))]">
+                <div className="flex items-center bg-white/80 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {rating}
                 </div>
-              ))}
-            </div>
-          ))}
-        </div>
-        
-        {/* Legend */}
-        <div className="mt-4 flex items-center justify-between text-xs text-gray-600">
-          <span>Low Risk</span>
-          <div className="flex space-x-1">
-            <div className="w-4 h-4 bg-green-200 rounded"></div>
-            <div className="w-4 h-4 bg-green-400 rounded"></div>
-            <div className="w-4 h-4 bg-yellow-400 rounded"></div>
-            <div className="w-4 h-4 bg-orange-400 rounded"></div>
-            <div className="w-4 h-4 bg-red-400 rounded"></div>
-            <div className="w-4 h-4 bg-red-500 rounded"></div>
+                {heatmapData[ratingIndex].map((value, exposureIndex) => (
+                  <button
+                    type="button"
+                    key={`${rating}-${exposureIndex}`}
+                    className="flex min-h-[48px] items-center justify-center px-3 py-2 text-sm font-semibold transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-900/20"
+                    style={getCellStyle(value)}
+                    title={`${rating} rating, ${exposureBands[exposureIndex]}: ${value} customers`}
+                  >
+                    {value}
+                  </button>
+                ))}
+              </div>
+            ))}
           </div>
-          <span>High Risk</span>
+        </div>
+
+        <div className="flex flex-col gap-3 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold uppercase tracking-wide text-slate-400">Legend</span>
+            <div className="flex items-center gap-1">
+              {[0.1, 0.25, 0.4, 0.55, 0.7, 0.85].map((intensity) => {
+                const style = getCellStyle(maxValue * intensity);
+                return <span key={intensity} className="h-3 w-6 rounded-full" style={{ background: style.background }} />;
+              })}
+            </div>
+            <span>Low risk → High risk</span>
+          </div>
+          <p className="text-xs text-slate-600">{getSummary()}</p>
         </div>
       </CardContent>
     </Card>

--- a/src/components/RiskHeatmap.tsx
+++ b/src/components/RiskHeatmap.tsx
@@ -1,5 +1,7 @@
 
+import { useId, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 const RiskHeatmap = () => {
   const ratings = ["AAA", "AA", "A", "BBB", "BB"];
@@ -15,6 +17,11 @@ const RiskHeatmap = () => {
   ];
 
   const maxValue = Math.max(...heatmapData.flat());
+  const [activeCell, setActiveCell] = useState({ ratingIndex: 0, exposureIndex: 0 });
+  const activeValue = heatmapData[activeCell.ratingIndex]?.[activeCell.exposureIndex] ?? 0;
+  const activeRating = ratings[activeCell.ratingIndex] ?? ratings[0];
+  const activeExposure = exposureBands[activeCell.exposureIndex] ?? exposureBands[0];
+  const summaryId = useId();
 
   const getCellStyle = (value: number) => {
     const intensity = value / maxValue;
@@ -59,35 +66,60 @@ const RiskHeatmap = () => {
         <p className="text-sm text-gray-600">Exposure vs credit rating matrix with intensity-driven insights</p>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="overflow-hidden rounded-2xl border border-slate-200/80 bg-slate-50/60 shadow-inner">
-          <div className="grid grid-cols-[120px_repeat(5,_minmax(0,_1fr))] divide-x divide-slate-200/70 text-xs font-medium uppercase tracking-wide text-slate-500">
-            <div className="bg-white/80 px-3 py-3 text-left">Rating / Exposure</div>
-            {exposureBands.map((band) => (
-              <div key={band} className="bg-white/60 px-3 py-3 text-center">
-                {band}
-              </div>
-            ))}
-          </div>
-          <div className="divide-y divide-slate-200/70 text-sm">
-            {ratings.map((rating, ratingIndex) => (
-              <div key={rating} className="grid grid-cols-[120px_repeat(5,_minmax(0,_1fr))]">
-                <div className="flex items-center bg-white/80 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                  {rating}
+        <div className="overflow-x-auto">
+          <div
+            className="min-w-[620px] overflow-hidden rounded-2xl border border-slate-200/80 bg-slate-50/60 shadow-inner"
+            role="grid"
+            aria-label="Customer distribution by credit rating and exposure band"
+          >
+            <div className="grid grid-cols-[minmax(116px,_0.9fr)_repeat(5,_minmax(0,_1fr))] divide-x divide-slate-200/70 text-xs font-medium uppercase tracking-wide text-slate-500 md:grid-cols-[140px_repeat(5,_minmax(0,_1fr))]" role="row">
+              <div className="bg-white/80 px-3 py-3 text-left" role="columnheader">Rating / Exposure</div>
+              {exposureBands.map((band) => (
+                <div key={band} className="bg-white/60 px-3 py-3 text-center" role="columnheader">
+                  {band}
                 </div>
-                {heatmapData[ratingIndex].map((value, exposureIndex) => (
-                  <button
-                    type="button"
-                    key={`${rating}-${exposureIndex}`}
-                    className="flex min-h-[48px] items-center justify-center px-3 py-2 text-sm font-semibold transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-900/20"
-                    style={getCellStyle(value)}
-                    title={`${rating} rating, ${exposureBands[exposureIndex]}: ${value} customers`}
-                  >
-                    {value}
-                  </button>
-                ))}
-              </div>
-            ))}
+              ))}
+            </div>
+            <div className="divide-y divide-slate-200/70 text-sm">
+              {ratings.map((rating, ratingIndex) => (
+                <div key={rating} className="grid grid-cols-[minmax(116px,_0.9fr)_repeat(5,_minmax(0,_1fr))] md:grid-cols-[140px_repeat(5,_minmax(0,_1fr))]" role="row">
+                  <div className="flex items-center bg-white/80 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500" role="rowheader">
+                    {rating}
+                  </div>
+                  {heatmapData[ratingIndex].map((value, exposureIndex) => (
+                    <button
+                      type="button"
+                      key={`${rating}-${exposureIndex}`}
+                      className={cn(
+                        "flex min-h-[48px] items-center justify-center px-3 py-2 text-sm font-semibold transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-slate-900/20",
+                        activeCell.ratingIndex === ratingIndex && activeCell.exposureIndex === exposureIndex && "ring-2 ring-slate-900/60 ring-offset-2 ring-offset-slate-50"
+                      )}
+                      style={getCellStyle(value)}
+                      title={`${rating} rating, ${exposureBands[exposureIndex]}: ${value} customers`}
+                      onClick={() => setActiveCell({ ratingIndex, exposureIndex })}
+                      onFocus={() => setActiveCell({ ratingIndex, exposureIndex })}
+                      aria-pressed={activeCell.ratingIndex === ratingIndex && activeCell.exposureIndex === exposureIndex}
+                      aria-label={`${value} customers with ${rating} rating in the ${exposureBands[exposureIndex]} exposure band`}
+                      aria-describedby={summaryId}
+                    >
+                      {value}
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
           </div>
+        </div>
+
+        <div
+          id={summaryId}
+          role="status"
+          aria-live="polite"
+          className="rounded-xl bg-slate-900/5 px-4 py-3 text-sm text-slate-700"
+        >
+          <span className="font-semibold text-slate-900">{activeRating}</span> rating ·{" "}
+          <span className="font-semibold text-slate-900">{activeExposure}</span> exposure band —{" "}
+          {activeValue.toLocaleString()} customers in this segment.
         </div>
 
         <div className="flex flex-col gap-3 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">

--- a/src/components/TopClientsSpotlight.tsx
+++ b/src/components/TopClientsSpotlight.tsx
@@ -1,0 +1,101 @@
+import { Link } from "react-router-dom";
+import { ArrowUpRight, Building2 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import { CustomerDataService } from "@/services/customerData";
+
+const TopClientsSpotlight = () => {
+  const topClients = CustomerDataService.getAllCustomers()
+    .sort((a, b) => b.exposure - a.exposure)
+    .slice(0, 3);
+
+  const maxExposure = topClients[0]?.exposure ?? 1;
+
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount);
+
+  const getRatingTone = (rating: string) => {
+    const tones: Record<string, string> = {
+      AAA: "bg-emerald-100 text-emerald-800",
+      AA: "bg-emerald-100 text-emerald-800",
+      A: "bg-sky-100 text-sky-800",
+      BBB: "bg-amber-100 text-amber-800",
+      BB: "bg-orange-100 text-orange-800",
+      B: "bg-rose-100 text-rose-800",
+      CCC: "bg-rose-100 text-rose-800",
+    };
+
+    return tones[rating] ?? "bg-slate-100 text-slate-800";
+  };
+
+  return (
+    <div className="grid gap-4 md:grid-cols-3">
+      {topClients.map((client, index) => (
+        <Card
+          key={client.id}
+          className="group flex flex-col justify-between border border-slate-200/80 bg-white/90 shadow-sm transition-all hover:-translate-y-1 hover:shadow-lg"
+        >
+          <CardContent className="flex flex-1 flex-col gap-4 p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-semibold text-slate-500">#{index + 1}</span>
+                  <Badge className={`${getRatingTone(client.rating)} font-medium`}>{client.rating}</Badge>
+                </div>
+                <Link
+                  to={`/customer/${client.id}`}
+                  className="mt-2 inline-flex items-center gap-2 text-lg font-semibold text-slate-900 transition-colors hover:text-blue-600"
+                >
+                  <Building2 className="h-5 w-5 text-slate-400" />
+                  {client.name}
+                </Link>
+              </div>
+              <Link
+                to={`/customer/${client.id}`}
+                className="rounded-full border border-transparent bg-slate-100 p-2 text-slate-500 transition-colors hover:border-blue-500/40 hover:bg-blue-50 hover:text-blue-600"
+                aria-label={`Open ${client.name} overview`}
+              >
+                <ArrowUpRight className="h-4 w-4" />
+              </Link>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-sm text-slate-500">
+                <span>Exposure</span>
+                <span className="font-semibold text-slate-900">{formatCurrency(client.exposure)}</span>
+              </div>
+              <Progress value={(client.exposure / maxExposure) * 100} className="h-2" />
+            </div>
+
+            <div className="grid grid-cols-2 gap-3 text-xs text-slate-500">
+              <div>
+                <p className="font-semibold uppercase tracking-wide text-slate-400">Sector</p>
+                <p className="text-slate-700">{client.sector}</p>
+              </div>
+              <div>
+                <p className="font-semibold uppercase tracking-wide text-slate-400">Region</p>
+                <p className="text-slate-700">{client.region}</p>
+              </div>
+              <div>
+                <p className="font-semibold uppercase tracking-wide text-slate-400">PD</p>
+                <p className="text-slate-700">{client.pd.toFixed(1)}%</p>
+              </div>
+              <div>
+                <p className="font-semibold uppercase tracking-wide text-slate-400">Expected loss</p>
+                <p className="text-rose-600">{formatCurrency(client.expectedLoss)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+};
+
+export default TopClientsSpotlight;

--- a/src/components/TopExposuresTable.tsx
+++ b/src/components/TopExposuresTable.tsx
@@ -89,20 +89,23 @@ const TopExposuresTable = () => {
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div>
             <CardTitle className="text-lg">Top Exposures</CardTitle>
             <p className="text-sm text-gray-600">Highest risk customers by exposure amount</p>
           </div>
-          <Button variant="outline" size="sm">
-            <ExternalLink className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <div className="flex items-center gap-2 text-xs text-gray-500">
+            <span className="hidden sm:inline text-gray-400">Sort to reprioritize reviews</span>
+            <Button variant="outline" size="sm" className="h-9">
+              <ExternalLink className="h-4 w-4 mr-2" />
+              Export
+            </Button>
+          </div>
         </div>
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto">
-          <table className="w-full">
+          <table className="w-full min-w-[720px] text-sm">
             <thead>
               <tr className="border-b">
                 <th className="text-left py-3 px-2">
@@ -176,9 +179,9 @@ const TopExposuresTable = () => {
                 </th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="divide-y">
               {sortedData.map((row, index) => (
-                <tr key={index} className="border-b hover:bg-gray-50 transition-colors">
+                <tr key={index} className="transition-colors hover:bg-gray-50">
                   <td className="py-3 px-2">
                     <Link to={`/customer/${row.customerId}`} className="block hover:bg-gray-50 transition-colors">
                       <div className="font-medium text-gray-900 hover:text-blue-600">{row.customer}</div>
@@ -189,7 +192,7 @@ const TopExposuresTable = () => {
                     {formatCurrency(row.exposure)}
                   </td>
                   <td className="py-3 px-2 text-center">
-                    <Badge className={getRatingColor(row.rating)}>
+                    <Badge className={`${getRatingColor(row.rating)} px-3 py-1 text-xs font-semibold`}>
                       {row.rating}
                     </Badge>
                   </td>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,17 +1,20 @@
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
-import { Search, TrendingUp, TrendingDown, Minus, Menu } from "lucide-react";
-import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, LineChart, Line, ComposedChart } from 'recharts';
+import { Search, Menu, TrendingUp, ShieldCheck, Users, ArrowRight } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { Link } from "react-router-dom";
 import DashboardSidebar from "@/components/DashboardSidebar";
 import KPICards from "@/components/KPICards";
 import CreditDistributionChart from "@/components/CreditDistributionChart";
 import RiskHeatmap from "@/components/RiskHeatmap";
 import TopExposuresTable from "@/components/TopExposuresTable";
+import TopClientsSpotlight from "@/components/TopClientsSpotlight";
+import { CustomerDataService } from "@/services/customerData";
 
 const Index = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -20,16 +23,57 @@ const Index = () => {
   const [selectedRegion, setSelectedRegion] = useState("all");
   const [searchTerm, setSearchTerm] = useState("");
 
+  type HighlightMetric = {
+    title: string;
+    value: string;
+    caption: string;
+    icon: LucideIcon;
+    accent: string;
+  };
+
+  const heroHighlights = useMemo<HighlightMetric[]>(() => {
+    const customers = CustomerDataService.getAllCustomers();
+    const totalExposure = customers.reduce((sum, customer) => sum + customer.exposure, 0);
+    const watchlist = customers.filter((customer) => customer.rating === "BB" || customer.rating === "B" || customer.rating === "CCC");
+    return [
+      {
+        title: "Exposure QoQ",
+        value: "+8.2%",
+        caption: "Growth in managed exposure",
+        icon: TrendingUp,
+        accent: "from-emerald-400/70 to-emerald-300/60",
+      },
+      {
+        title: "Watchlist clients",
+        value: watchlist.length.toLocaleString(),
+        caption: "Require targeted review",
+        icon: ShieldCheck,
+        accent: "from-amber-400/70 to-orange-400/60",
+      },
+      {
+        title: "Active portfolios",
+        value: `${customers.length.toLocaleString()} / ${Math.round(totalExposure / 1_000_000).toLocaleString()}M`,
+        caption: "Customers • Exposure managed",
+        icon: Users,
+        accent: "from-blue-400/70 to-sky-400/60",
+      },
+    ];
+  }, []);
+
   return (
     <div className="flex min-h-screen bg-gray-50">
       <DashboardSidebar isOpen={sidebarOpen} onToggle={() => setSidebarOpen(!sidebarOpen)} />
-      
-      <div className={`flex-1 transition-all duration-300 ${sidebarOpen ? 'ml-64' : 'ml-16'}`}>
+
+      <div
+        className={`flex-1 transition-all duration-300 ml-0 ${
+          sidebarOpen ? "lg:ml-64" : "lg:ml-20"
+        }`}
+      >
         {/* Header */}
         <header className="bg-white border-b border-gray-200 px-6 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
-              <Button 
+              <Button
                 variant="ghost" 
                 size="sm" 
                 onClick={() => setSidebarOpen(!sidebarOpen)}
@@ -49,9 +93,89 @@ const Index = () => {
         </header>
 
         {/* Main Content */}
-        <main className="p-6 space-y-6">
-          {/* KPI Cards */}
-          <KPICards />
+        <main className="space-y-6 px-4 py-6 sm:p-6">
+          {/* Hero Section */}
+          <section className="relative overflow-hidden rounded-3xl bg-slate-900 text-white shadow-xl">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,_rgba(56,189,248,0.2),_transparent_60%)]" aria-hidden="true" />
+            <div className="absolute inset-y-0 -left-10 w-1/3 bg-[radial-gradient(circle,_rgba(94,234,212,0.15),_transparent_70%)] blur-3xl" aria-hidden="true" />
+            <div className="relative z-10 flex flex-col gap-8 p-6 sm:p-10 lg:p-12">
+              <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+                <div className="max-w-2xl space-y-5">
+                  <Badge className="w-fit bg-white/10 text-xs font-semibold uppercase tracking-wide text-emerald-200">
+                    Intelligent portfolio oversight
+                  </Badge>
+                  <div className="space-y-4">
+                    <h2 className="text-3xl font-semibold leading-tight sm:text-4xl">
+                      Confidence in every credit decision
+                    </h2>
+                    <p className="text-base text-slate-200 sm:text-lg">
+                      Surface the riskiest exposures instantly, compare portfolios, and collaborate on proactive action plans without leaving the dashboard.
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-slate-200">
+                    <Button
+                      asChild
+                      size="lg"
+                      className="bg-white text-slate-900 hover:bg-white/90"
+                    >
+                      <Link to="/portfolio" className="flex items-center gap-2">
+                        Explore portfolio
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    </Button>
+                    <Button
+                      size="lg"
+                      variant="outline"
+                      className="border-white/30 bg-white/5 text-white hover:bg-white/10 hover:text-white"
+                    >
+                      Live risk briefing
+                    </Button>
+                    <span className="text-xs text-slate-300">
+                      Updated moments ago · Collaboration ready
+                    </span>
+                  </div>
+                </div>
+                <div className="grid w-full gap-4 sm:grid-cols-2 lg:max-w-sm">
+                  {heroHighlights.map((item) => {
+                    const Icon = item.icon;
+                    return (
+                      <div
+                        key={item.title}
+                        className="rounded-2xl bg-gradient-to-br from-white/10 via-white/5 to-white/5 p-4 backdrop-blur"
+                      >
+                        <div className={`mb-3 inline-flex rounded-xl bg-gradient-to-br ${item.accent} p-2 text-slate-900/90`}
+                          aria-hidden="true"
+                        >
+                          <Icon className="h-5 w-5" />
+                        </div>
+                        <div className="space-y-1">
+                          <p className="text-xs uppercase tracking-wide text-slate-300">{item.title}</p>
+                          <p className="text-2xl font-semibold">{item.value}</p>
+                          <p className="text-xs text-slate-400">{item.caption}</p>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+              <div>
+                <KPICards />
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <h3 className="text-xl font-semibold text-gray-900">Top clients spotlight</h3>
+                <p className="text-sm text-gray-600">Stay ahead of concentrations with quick access to your largest exposures.</p>
+              </div>
+              <Button variant="ghost" size="sm" className="hidden sm:inline-flex" asChild>
+                <Link to="#top-exposures">View full table</Link>
+              </Button>
+            </div>
+            <TopClientsSpotlight />
+          </section>
 
           {/* Filters */}
           <Card>
@@ -116,14 +240,18 @@ const Index = () => {
             </CardContent>
           </Card>
 
-          {/* Charts Row */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <CreditDistributionChart />
-            <RiskHeatmap />
+          {/* Analytics Layout */}
+          <div className="grid gap-6 xl:grid-cols-[2fr,1.1fr]" id="top-exposures">
+            <div className="space-y-6">
+              <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+                <CreditDistributionChart />
+                <RiskHeatmap />
+              </div>
+            </div>
+            <div className="space-y-6">
+              <TopExposuresTable />
+            </div>
           </div>
-
-          {/* Top Exposures Table */}
-          <TopExposuresTable />
         </main>
       </div>
     </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,6 +15,7 @@ import RiskHeatmap from "@/components/RiskHeatmap";
 import TopExposuresTable from "@/components/TopExposuresTable";
 import TopClientsSpotlight from "@/components/TopClientsSpotlight";
 import { CustomerDataService } from "@/services/customerData";
+import { cn } from "@/lib/utils";
 
 const Index = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -65,9 +66,11 @@ const Index = () => {
       <DashboardSidebar isOpen={sidebarOpen} onToggle={() => setSidebarOpen(!sidebarOpen)} />
 
       <div
-        className={`flex-1 transition-all duration-300 ml-0 ${
+        className={cn(
+          "flex-1 transition-all duration-300",
+          sidebarOpen ? "ml-64" : "ml-16",
           sidebarOpen ? "lg:ml-64" : "lg:ml-20"
-        }`}
+        )}
       >
         {/* Header */}
         <header className="bg-white border-b border-gray-200 px-6 py-4">
@@ -241,9 +244,9 @@ const Index = () => {
           </Card>
 
           {/* Analytics Layout */}
-          <div className="grid gap-6 xl:grid-cols-[2fr,1.1fr]" id="top-exposures">
+          <div className="grid gap-6 2xl:grid-cols-[minmax(0,2fr)_minmax(0,1.1fr)]" id="top-exposures">
             <div className="space-y-6">
-              <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+              <div className="grid grid-cols-1 gap-6 2xl:grid-cols-2">
                 <CreditDistributionChart />
                 <RiskHeatmap />
               </div>


### PR DESCRIPTION
## Summary
- redesign the landing hero with gradient styling, guided CTAs, and inline KPI highlights for better first impression
- add a top clients spotlight card deck and reposition the full exposures table beside the analytics to surface key customers sooner
- refresh the credit distribution and risk heatmap visuals with gradients, annotations, and improved legends for readability

## Testing
- npm run lint *(fails: existing lint issues in legacy ui components and config)*

------
https://chatgpt.com/codex/tasks/task_e_68f63072e208832daef6f62c878566da